### PR TITLE
Fixed the default formatting

### DIFF
--- a/src/Console/stubs/tests/Feature/Auth/LoginTest.php
+++ b/src/Console/stubs/tests/Feature/Auth/LoginTest.php
@@ -172,11 +172,11 @@ class LoginTest extends TestCase
             $this->getTooManyLoginAttemptsMessage(),
             collect(
                 $response
-                ->baseResponse
-                ->getSession()
-                ->get('errors')
-                ->getBag('default')
-                ->get('email')
+                    ->baseResponse
+                    ->getSession()
+                    ->get('errors')
+                    ->getBag('default')
+                    ->get('email')
             )->first()
         );
         $this->assertTrue(session()->hasOldInput('email'));


### PR DESCRIPTION
PHPStorm and PHPCSFixer by default indents the currently-unindented block.

Holding off with this for a few days to gather feedback.